### PR TITLE
fix: server shutdown logging and request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ How to release a new version:
 - Manually release new version.
 
 ## [Unreleased]
+
+## [0.7.1] - 2024-07-11
 ### Changed
 - Canceling `Server.Run()` context no longer cancels requests base context.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ How to release a new version:
 - Manually release new version.
 
 ## [Unreleased]
+### Changed
+- Canceling `Server.Run()` context no longer cancels requests base context.
+
+### Fixed
+- No `Error` logging on successful graceful shut down.
 
 ## [0.7.0] - 2024-03-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ How to release a new version:
 ### Added
 - Added Changelog.
 
-[Unreleased]: https://github.com/strvcom/strv-backend-go-net/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/strvcom/strv-backend-go-net/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/strvcom/strv-backend-go-net/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/strvcom/strv-backend-go-net/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/strvcom/strv-backend-go-net/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/strvcom/strv-backend-go-net/compare/v0.6.0...v0.6.1


### PR DESCRIPTION
- Canceling `Server.Run()` context no longer cancels requests base context.
  - because I'd argue there is no usecase where you would want to not-so-gracefully shutdown all running requests. More reasonable use case is to let requests finish (for up to default 30 secs, or before SIGKILL), and if they do not finish, there is nothing too much better that force killing the app

- No `Error` logging on successful graceful shut down.
  - because it is weird to see error logs when tasks in ECS are swapped as they are supposed to.

- few comments as I was confused what does the hook actually do (RegisterOnShutdown does not wait for hooks to complete, but then there is explicit waiting for those hooks before Run returns)

related: https://github.com/strvcom/backend-go-template-api/pull/166