### PR TITLE
feat(http): make ResponseWriter public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ How to release a new version:
 ### Removed
 - package `http/param`: can no longer change the tag value prefix the parser reacts to (e.g. from `param:"query=q"` to `param:"myPrefix=q"`)
 
+### Changed
+- ResponseWriter has been moved to the `http` package and is no longer private.
+
 ## [0.7.1] - 2024-07-11
 ### Changed
 - Canceling `Server.Run()` context no longer cancels requests base context.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ When you are creating a [feature request](#how-do-i-submit-a-feature-request), p
 Planned features are tracked as [GitHub issues](https://github.com/strvcom/strv-backend-go-net/issues).
 Create an issue on the repository and provide the following information:
 - Use a clear and descriptive title for the issue to identify the feature request.
-- Provide a step-by-step description of the feature request in as much details as possible.
+- Provide a step-by-step description of the feature request in as many details as possible.
 - Provide specific examples to demonstrate the usage of the feature. Include copy/pasteable snippets which you use in those examples, as Markdown code blocks.
 - Describe the current behavior and explain which behavior you expected to see instead and why.
 - Explain why this feature would be useful to most users.

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"go.strv.io/net"
-	"go.strv.io/net/internal"
 )
 
 const (
@@ -65,9 +64,9 @@ func RecoverMiddleware(l *slog.Logger, opts ...RecoverMiddlewareOption) func(htt
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if re := recover(); re != nil {
-					rw, ok := w.(*internal.ResponseWriter)
+					rw, ok := w.(*ResponseWriter)
 					if !ok {
-						rw = internal.NewResponseWriter(w, l)
+						rw = NewResponseWriter(w, l)
 					}
 
 					rw.SetPanicObject(re)
@@ -101,9 +100,9 @@ func RecoverMiddleware(l *slog.Logger, opts ...RecoverMiddlewareOption) func(htt
 func LoggingMiddleware(l *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			rw, ok := w.(*internal.ResponseWriter)
+			rw, ok := w.(*ResponseWriter)
 			if !ok {
-				rw = internal.NewResponseWriter(w, l)
+				rw = NewResponseWriter(w, l)
 			}
 
 			requestStart := time.Now()
@@ -156,7 +155,7 @@ func (r RequestData) LogValue() slog.Value {
 }
 
 // withRequestData returns slog with filled fields.
-func withRequestData(l *slog.Logger, rw *internal.ResponseWriter, rd RequestData) *slog.Logger {
+func withRequestData(l *slog.Logger, rw *ResponseWriter, rd RequestData) *slog.Logger {
 	errorObject := rw.ErrorObject()
 	panicObject := rw.PanicObject()
 	if errorObject != nil {

--- a/http/response.go
+++ b/http/response.go
@@ -3,8 +3,6 @@ package http
 import (
 	"fmt"
 	"net/http"
-
-	"go.strv.io/net/internal"
 )
 
 type ResponseOptions struct {
@@ -79,7 +77,7 @@ func WriteErrorResponse(
 		return fmt.Errorf("response encoding: %w", err)
 	}
 
-	if rw, ok := w.(*internal.ResponseWriter); ok {
+	if rw, ok := w.(*ResponseWriter); ok {
 		rw.SetErrorObject(o.Err)
 	}
 

--- a/http/responsewriter.go
+++ b/http/responsewriter.go
@@ -1,4 +1,4 @@
-package internal
+package http
 
 import (
 	"bufio"

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.strv.io/net/internal"
 )
 


### PR DESCRIPTION
`ResponseWriter` is an important structure accessed by the middleware and used indirectly by the signature package. If we expose it, it's possible to build custom middleware on top of our existing ones, reusing the data stored in the ResponseWriter.