### PR TITLE
feat(param): parse embedded struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ How to release a new version:
 - Manually release new version.
 
 ## [Unreleased]
+### Added
+- package `http/param`: can parse into embedded structs.
+
+### Removed
+- package `http/param`: can no longer change the tag value prefix the parser reacts to (e.g. from `param:"query=q"` to `param:"myPrefix=q"`)
 
 ## [0.7.1] - 2024-07-11
 ### Changed

--- a/http/param/param_test.go
+++ b/http/param/param_test.go
@@ -481,7 +481,7 @@ type variousTagsStruct struct {
 
 func TestTagWithModifierTagResolver(t *testing.T) {
 	const correctKey = "key"
-	const correctLocation = "location"
+	const correctPrefix = "location"
 
 	testCases := []struct {
 		fieldName     string
@@ -516,44 +516,11 @@ func TestTagWithModifierTagResolver(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.fieldName, func(t *testing.T) {
-			tagResolver := TagWithModifierTagResolver(correctKey, correctLocation)
+			parser := Parser{ParamTagResolver: TagNameResolver(correctKey)}
 			structField, found := reflect.TypeOf(variousTagsStruct{}).FieldByName(tc.fieldName)
 			require.True(t, found)
 
-			paramName, ok := tagResolver(structField.Tag)
-
-			assert.Equal(t, tc.expectedParam, paramName)
-			assert.Equal(t, tc.expectedOk, ok)
-		})
-	}
-}
-
-func TestFixedTagNameParamTagResolver(t *testing.T) {
-	const correctKey = "key"
-
-	testCases := []struct {
-		fieldName     string
-		expectedParam string
-		expectedOk    bool
-	}{
-		{
-			fieldName:     "A",
-			expectedParam: "location=val",
-			expectedOk:    true,
-		},
-		{
-			fieldName:     "D",
-			expectedParam: "",
-			expectedOk:    false,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.fieldName, func(t *testing.T) {
-			tagResolver := FixedTagNameParamTagResolver(correctKey)
-			structField, found := reflect.TypeOf(variousTagsStruct{}).FieldByName(tc.fieldName)
-			require.True(t, found)
-
-			paramName, ok := tagResolver(structField.Tag)
+			paramName, ok := parser.resolveTagWithModifier(structField.Tag, correctPrefix)
 
 			assert.Equal(t, tc.expectedParam, paramName)
 			assert.Equal(t, tc.expectedOk, ok)


### PR DESCRIPTION
Param package can parse into embedded structs. Inspired by `json` package, where the package CAN set unexported embedded struct (only if non-pointer or non-nil-pointer), as long as it's fields are exported.

Also removed some useless customization to simplify the package (separate commit)